### PR TITLE
Adding links to GitHub repo to Makefile.PL

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -25,4 +25,10 @@ WriteMakefile(
     },
     dist                => { COMPRESS => 'gzip -9f', SUFFIX => 'gz', },
     clean               => { FILES => 'WebService-Instagram-*' },
+    META_MERGE => {
+        resources  => {
+            homepage => 'https://github.com/odem5442/WebService-Instagram',
+            repository => 'git://github.com/odem5442/WebService-Instagram.git',
+        }
+    },
 );


### PR DESCRIPTION
This addition will add link 'Clone repository' on metacpan page.

Here is an example how it will look like:

![screen shot 2014-04-29 at 11 22 34](https://cloud.githubusercontent.com/assets/47263/2826412/27de51fc-cf6f-11e3-9342-bdabf51e05cb.png)
